### PR TITLE
fixed typo s/geoemtries/geometries/

### DIFF
--- a/streamlit-webapp/app.py
+++ b/streamlit-webapp/app.py
@@ -102,5 +102,5 @@ if button_fix:
         st.stop()
     json_json = dict(json.loads(json_string.replace("'", '"')))
     fixed_fc = geojson_validator.fix_geometries(json_json)
-    col2.success("Fixed geoemtries")
+    col2.success("Fixed geometries")
     col2.write(fixed_fc)


### PR DESCRIPTION
fixed typo s/geoemtries/geometries/

![image](https://github.com/user-attachments/assets/5800f415-56dd-4b3c-91e1-ff0f0afce1bb)
