### PR TITLE
Use shapely built-ins for fixes and fix coordinate-check false negatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Update your installation to the latest version:
     pip install geojson-validator --upgrade
     ```
 
+## Unreleased
+
+- Fix `fix_geometries` `duplicate_nodes` removing meaningful collinear vertices (use `shapely.remove_repeated_points` instead of `simplify(0)`)
+- Fix `3d_coordinates` and `excessive_coordinate_precision` checks missing issues on vertices after the first two (now scan all coordinates)
+- `validate_geometries` no longer crashes on geometries shapely cannot parse (e.g. mixed 2D/3D coordinates); raw-JSON checks still run, shapely-based checks are skipped
+- Winding-order fixes now use `shapely.geometry.polygon.orient`
+- `read_geojson_file_or_url` raises a clear HTTP error instead of silently falling through to a file open on non-200 responses
+- Logging is configured in a single module instead of three (no longer wipes the global loguru logger multiple times on import)
+- Require Python >= 3.9
+
 ## 0.6.0
 **November 29, 2024**
 

--- a/geojson_validator/checks_problematic.py
+++ b/geojson_validator/checks_problematic.py
@@ -30,13 +30,9 @@ def check_duplicate_nodes(geometry: dict) -> bool:
     return has_duplicates and not only_closed_ring_duplicate
 
 
-def check_excessive_coordinate_precision(
-    geometry: dict, precision=6, n_first_coords=2
-) -> bool:
-    """Return True if coordinates have more than 6 decimal places in the longitude."""
-    # For speedup, by default only checks the x&y coordinates of the n_first_coords=2 coordinate pairs.
-    coords = geometry["coordinates"][0][:n_first_coords]
-    for coord_xy in coords:
+def check_excessive_coordinate_precision(geometry: dict, precision=6) -> bool:
+    """Return True if any coordinate has more than `precision` decimal places."""
+    for coord_xy in geometry["coordinates"][0]:
         for coord in coord_xy:
             splits = str(coord).split(".")
             if (
@@ -53,10 +49,9 @@ def check_excessive_vertices(
     return len(geometry["coordinates"][0]) > 999
 
 
-def check_3d_coordinates(geometry: dict, n_first_coords=2) -> bool:
-    """Return True if any coordinates are more than 2D."""
-    # TODO: should all coordinates be checked?
-    for coords in geometry["coordinates"][0][:n_first_coords]:
+def check_3d_coordinates(geometry: dict) -> bool:
+    """Return True if any coordinate is more than 2D."""
+    for coords in geometry["coordinates"][0]:
         if len(coords) > 2:
             return True
     return False

--- a/geojson_validator/fixes.py
+++ b/geojson_validator/fixes.py
@@ -1,40 +1,32 @@
-from shapely.geometry import Polygon, LinearRing
+from shapely import remove_repeated_points
+from shapely.geometry import Polygon
+from shapely.geometry.polygon import orient
 
 
 # Needs manual check: check_less_three_unique_nodes
 # Possible but problematic: check_outside_lat_lon_boundaries, check_inner_and_exterior_ring_intersect
 def fix_unclosed(geom: Polygon):
     """Close the geometry by adding the first coordinate at the end if not closed."""
-    # TODO Shapely closes anyway
-    coords = list(geom.exterior.coords)
-    if coords[0] != coords[-1]:
-        coords.append(coords[0])
-    closed_polygon = Polygon(coords)
-    return closed_polygon
-
-
-def fix_exterior_not_ccw(geom: Polygon):
-    """Reorder exterior ring to be counter-clockwise."""
-    if not geom.exterior.is_ccw:
-        geom = Polygon(list(geom.exterior.coords)[::-1])
+    # Constructing a shapely Polygon already closes the ring, so by the time a geometry
+    # reaches this function it is closed. Kept for explicit, name-based fix dispatch.
     return geom
 
 
+def fix_exterior_not_ccw(geom: Polygon):
+    """Orient the polygon to the GeoJSON right-hand rule (exterior CCW, interiors CW)."""
+    return orient(geom, sign=1.0)
+
+
 def fix_interior_not_cw(geom: Polygon):
-    """Reorder any interior rings to be clockwise."""
-    interiors = []
-    exterior = LinearRing(geom.exterior)
-    for interior in geom.interiors:
-        if interior.is_ccw:
-            interiors.append(LinearRing(interior.coords[::-1]))
-        else:
-            interiors.append(LinearRing(interior))
-    return Polygon(exterior, interiors)
+    """Orient the polygon to the GeoJSON right-hand rule (exterior CCW, interiors CW)."""
+    return orient(geom, sign=1.0)
 
 
 def fix_duplicate_nodes(geom: Polygon):
-    """Remove duplicate nodes from the geometry."""
-    return geom.simplify(0)
+    """Remove consecutive duplicate nodes, preserving meaningful (collinear) vertices."""
+    # shapely.remove_repeated_points only drops repeated points; unlike simplify(0) it does
+    # not collapse collinear vertices.
+    return remove_repeated_points(geom, 0)
 
 
 # def fix_excessive_coordinate_precision(geom: Polygon):

--- a/geojson_validator/fixes_utils.py
+++ b/geojson_validator/fixes_utils.py
@@ -1,16 +1,11 @@
 from typing import List
 import copy
-import sys
 
 from shapely.geometry import shape
 from loguru import logger
 
 
 from . import fixes
-
-logger.remove()
-logger_format = "{time:YYYY-MM-DD_HH:mm:ss.SSS} | {message}"
-logger.add(sink=sys.stderr, format=logger_format, level="INFO")
 
 
 def apply_fix(criterium: str, shapely_geom):
@@ -34,7 +29,13 @@ def process_fix(fc, geometry_validation_results: dict, criteria: List[str]):
                 if geometry["type"] != "Polygon":
                     logger.info("Currently only fixing polygons, skipping")
                     continue
-                geom = shape(geometry)
+                try:
+                    geom = shape(geometry)
+                except (TypeError, ValueError):
+                    logger.info(
+                        "Geometry could not be parsed by shapely, skipping fix."
+                    )
+                    continue
                 geom_fixed = apply_fix(criterium, geom)
                 fc_copy["features"][idx]["geometry"] = geom_fixed.__geo_interface__
             elif isinstance(idx, dict):  # multitype geometry e.g. idx is {0: [1, 2]}

--- a/geojson_validator/geometry_utils.py
+++ b/geojson_validator/geometry_utils.py
@@ -18,8 +18,8 @@ def read_geojson_file_or_url(fp_or_url: Union[str, Path]):
         raise ValueError("Filepath or URL must be a geojson or json file")
     if urlparse(str(fp_or_url)).scheme in ("http", "https", "ftp", "ftps"):
         response = requests.get(str(fp_or_url), timeout=5)
-        if response.status_code == 200:  # Check if the request was successful
-            return response.json()
+        response.raise_for_status()  # raise a clear HTTP error instead of falling through to a file open
+        return response.json()
 
     with Path(fp_or_url).open(encoding="UTF-8") as f:
         return json.load(f)
@@ -90,10 +90,11 @@ def prepare_geometries_for_checks(geometry):
     # Initiating the shapely type in each check function specifically is time intensive.
     try:
         shapely_geom = shape(geometry)
-    except TypeError as e:
-        raise TypeError(
-            f"Could not convert geometry to shapely object, likely wrong type: {geometry}"
-        ) from e
+    except (TypeError, ValueError):
+        # e.g. mixed 2D/3D coordinates make shapely raise. Return None so the raw-JSON
+        # based checks (3d_coordinates, precision, etc.) can still run; shapely-based
+        # checks are skipped for this geometry.
+        shapely_geom = None
     # To avoid adjusting the checks code for each geometry type, they are brought to the same
     # list depth (not ideal but okay).
     geometry_type = geometry.get("type", None)

--- a/geojson_validator/geometry_validation.py
+++ b/geojson_validator/geometry_validation.py
@@ -1,16 +1,10 @@
 from typing import List
-import sys
 from collections import Counter
 
 from loguru import logger
 
 from . import checks_invalid, checks_problematic
 from .geometry_utils import prepare_geometries_for_checks, extract_single_geometries
-
-logger.remove()
-logger_format = "{time:YYYY-MM-DD_HH:mm:ss.SSS} | {message}"
-logger.add(sink=sys.stderr, format=logger_format, level="INFO")
-
 
 ALL_ACCEPTED_GEOMETRY_TYPES = POI, MPOI, LS, MLS, POL, MPOL, GC = [
     "Point",
@@ -100,11 +94,16 @@ def apply_check(
     }
     relevant_geometry_type = VALIDATION_CRITERIA[criteria_type][criterium]["relevant"]
     if geometry_type in relevant_geometry_type:
+        required_input_type = VALIDATION_CRITERIA[criteria_type][criterium]["input"]
+        if required_input_type == "shapely_geom" and shapely_geom is None:
+            logger.info(
+                f"Skipping check '{criterium}', geometry could not be parsed by shapely."
+            )
+            return None
         check_module = (
             checks_invalid if criteria_type == "invalid" else checks_problematic
         )
         check_func = getattr(check_module, f"check_{criterium}")
-        required_input_type = VALIDATION_CRITERIA[criteria_type][criterium]["input"]
         return check_func(geometry_input_options[required_input_type])
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "geojson-validator"
 version = "0.6.0"
 description = "Validates and fixes GeoJSON"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "MIT" }
 authors = [{ name = "Christoph Rieke", email = "christoph.k.rieke@gmail.com" }]
 keywords = ["geojson", "validation", "GIS"]

--- a/tests/test_checks_problematic.py
+++ b/tests/test_checks_problematic.py
@@ -58,6 +58,17 @@ def test_check_excessive_coordinate_precision_no_after_comma_succeds():
     )
 
 
+def test_check_excessive_coordinate_precision_on_later_vertex():
+    # Excessive precision only on the 3rd vertex; must still be detected (not just first 2).
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [
+            [[0.0, 0.0], [1.0, 0.0], [1.1234567, 1.0], [0.0, 1.0], [0.0, 0.0]]
+        ],
+    }
+    assert checks_problematic.check_excessive_coordinate_precision(geometry)
+
+
 def test_check_excessive_vertices():
     geometry = read_geojson(
         "./tests/data/problematic_geometries/problematic_excessive_vertices.geojson",
@@ -71,6 +82,15 @@ def test_check_3d_coordinates():
         "./tests/data/problematic_geometries/problematic_3d_coordinates.geojson",
         geometries=True,
     )
+    assert checks_problematic.check_3d_coordinates(geometry)
+
+
+def test_check_3d_coordinates_on_later_vertex():
+    # 3D coordinate only on the 3rd vertex; must still be detected (not just first 2).
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[0, 0], [1, 0], [1, 1, 5], [0, 1], [0, 0]]],
+    }
     assert checks_problematic.check_3d_coordinates(geometry)
 
 

--- a/tests/test_fixes.py
+++ b/tests/test_fixes.py
@@ -50,6 +50,18 @@ def test_fix_duplicate_nodes():
     )
 
 
+def test_fix_duplicate_nodes_preserves_collinear_vertices():
+    # A collinear vertex (0.5, 0) is a meaningful node, not a duplicate; it must be kept.
+    geom = shape(
+        {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [0.5, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        }
+    )
+    fixed = fixes.fix_duplicate_nodes(geom)
+    assert (0.5, 0.0) in list(fixed.exterior.coords)
+
+
 # def test_fix_excessive_coordinate_precision():
 #     geometry = read_geojson(
 #         "./tests/data/problematic_geometries/problematic_excessive_coordinate_precision.geojson",

--- a/tests/test_fixes_utils.py
+++ b/tests/test_fixes_utils.py
@@ -2,6 +2,37 @@ from .context import fixes_utils
 from .fixtures import read_geojson
 
 
+def test_process_fix_skips_unparseable_geometry():
+    # Mixed 2D/3D coordinates cannot be parsed by shapely; process_fix must skip the
+    # geometry instead of crashing (matches validate_geometries' tolerance).
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[0, 0], [0, 0], [1, 0], [1, 1, 5], [0, 1], [0, 0]]
+                    ],
+                },
+            }
+        ],
+    }
+    geometry_validation_results = {
+        "invalid": {},
+        "problematic": {"duplicate_nodes": [0]},
+        "count_geometry_types": {"Polygon": 1},
+        "skipped_validation": [],
+    }
+    fixed_fc = fixes_utils.process_fix(
+        fc, geometry_validation_results, ["duplicate_nodes"]
+    )
+    # Unchanged (skipped), but no crash.
+    assert fixed_fc == fc
+
+
 def test_process_fix():
     fc = read_geojson(
         "./tests/data/invalid_geometries/invalid_exterior_not_ccw.geojson",

--- a/tests/test_geometry_validation.py
+++ b/tests/test_geometry_validation.py
@@ -115,6 +115,19 @@ def test_process_validation_multipolygon_in_geometrycollection():
     assert results["count_geometry_types"] == {"GeometryCollection": 1}
 
 
+def test_process_validation_mixed_dimension_does_not_crash():
+    # Mixed 2D/3D coordinates make shapely raise on construction; the raw-JSON checks
+    # (e.g. 3d_coordinates) must still run instead of crashing the whole validation.
+    geometries = [
+        {
+            "type": "Polygon",
+            "coordinates": [[[0, 0], [1, 0], [1, 1, 5], [0, 1], [0, 0]]],
+        }
+    ]
+    results = geometry_validation.process_validation(geometries, [], ["3d_coordinates"])
+    assert "3d_coordinates" in results["problematic"]
+
+
 def test_process_validation_multiple_types():
     # Second geometry in Multipolygon and third geometry is unclosed
     geometries = [


### PR DESCRIPTION
## Summary

Replaces custom geometry-fix code with shapely built-ins (now that the library depends on `shapely>=2.0.6`) and fixes several correctness issues found along the way. All assumptions were verified against shapely 2.1.2 and the existing test suite before changing anything.

## Correctness fixes
- **`fix_duplicate_nodes`**: `simplify(0)` → `shapely.remove_repeated_points`. `simplify(0)` runs Douglas–Peucker and was silently deleting valid **collinear** vertices, not just duplicates.
- **`check_3d_coordinates` / `check_excessive_coordinate_precision`**: only inspected the first two vertices (a speed shortcut), producing **false negatives** when the issue was on a later vertex. Now scan all coordinates of the ring.
- **`validate_geometries` / `fix_geometries` no longer crash** on geometries shapely cannot parse (e.g. mixed 2D/3D coordinates). Previously an uncaught `ValueError` killed the whole call. Now the raw-JSON checks still run and shapely-based checks/fixes are skipped for that geometry.

## Replacing custom code with shapely built-ins
- **Winding fixes** (`fix_exterior_not_ccw`, `fix_interior_not_cw`) → `shapely.geometry.polygon.orient(geom, sign=1.0)` — the RFC 7946 right-hand rule (exterior CCW, holes CW) in one call.
- **`fix_unclosed`** was reconstructing an already-closed ring (shapely closes on construction); now a documented pass-through.

## Robustness / hygiene
- `read_geojson_file_or_url`: `raise_for_status()` instead of silently falling through to a file-open on non-200.
- Logging configured in a single module instead of three (each previously called `logger.remove()` at import, wiping the global loguru logger in an order-dependent way). Default INFO-on behavior is unchanged.
- `requires-python` `>=3.8` → `>=3.9` (3.8 is EOL).

## Tests
`64 passed, 3 skipped`. New regression tests cover: precision/3D issues on a later vertex, `fix_duplicate_nodes` preserving collinear vertices, and validation/fix tolerating unparseable (mixed-dim) geometries.

## Known limitations (pre-existing, not changed here)
- The `3d_coordinates` / `excessive_coordinate_precision` checks scan only the first ring/part (`coordinates[0]`), consistent with the rest of the checks in the module — interior rings (holes) are still not scanned.
- `check_3d_coordinates` / `check_excessive_coordinate_precision` lost their `n_first_coords` keyword argument (it had no internal callers).