### PR TITLE
Fix fix_geometries not applying fixes to multigeometry parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Update your installation to the latest version:
 
 ## Unreleased
 
+- Fix `fix_geometries` not applying fixes to the sub-geometries of MultiPolygons/GeometryCollections
+  (results were written to a wrong key, leaving the coordinates unchanged)
+- `fix_geometries` returns plain lists instead of tuples in the fixed coordinates
 - Fix `fix_geometries` `duplicate_nodes` removing meaningful collinear vertices (use `shapely.remove_repeated_points` instead of `simplify(0)`)
 - Fix `3d_coordinates` and `excessive_coordinate_precision` checks missing issues on vertices after the first two (now scan all coordinates)
 - `validate_geometries` no longer crashes on geometries shapely cannot parse (e.g. mixed 2D/3D coordinates); raw-JSON checks still run, shapely-based checks are skipped

--- a/geojson_validator/fixes_utils.py
+++ b/geojson_validator/fixes_utils.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Union
 import copy
 
 from shapely.geometry import shape
@@ -9,9 +9,31 @@ from . import fixes
 
 
 def apply_fix(criterium: str, shapely_geom):
-    """Applies the correct check for the criteria"""
+    """Applies the correct fix for the criteria"""
     fix_func = getattr(fixes, f"fix_{criterium}")
     return fix_func(shapely_geom)
+
+
+def deep_list(obj):
+    """Converts nested coordinate tuples (e.g. from __geo_interface__) to plain JSON-style lists."""
+    if isinstance(obj, dict):
+        return {key: deep_list(value) for key, value in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [deep_list(value) for value in obj]
+    return obj
+
+
+def fix_single_geometry(geometry: dict, criterium: str) -> Union[dict, None]:
+    """Fixes one single-type geometry dict, returns the fixed geometry dict or None if not fixable."""
+    if geometry["type"] != "Polygon":
+        logger.info("Currently only fixing polygons, skipping")
+        return None
+    try:
+        geom = shape(geometry)
+    except (TypeError, ValueError):
+        logger.info("Geometry could not be parsed by shapely, skipping fix.")
+        return None
+    return deep_list(apply_fix(criterium, geom).__geo_interface__)
 
 
 def process_fix(fc, geometry_validation_results: dict, criteria: List[str]):
@@ -26,31 +48,30 @@ def process_fix(fc, geometry_validation_results: dict, criteria: List[str]):
         for idx in indices:
             if isinstance(idx, int):
                 geometry = fc_copy["features"][idx]["geometry"]
-                if geometry["type"] != "Polygon":
-                    logger.info("Currently only fixing polygons, skipping")
-                    continue
-                try:
-                    geom = shape(geometry)
-                except (TypeError, ValueError):
-                    logger.info(
-                        "Geometry could not be parsed by shapely, skipping fix."
-                    )
-                    continue
-                geom_fixed = apply_fix(criterium, geom)
-                fc_copy["features"][idx]["geometry"] = geom_fixed.__geo_interface__
+                fixed = fix_single_geometry(geometry, criterium)
+                if fixed is not None:
+                    fc_copy["features"][idx]["geometry"] = fixed
             elif isinstance(idx, dict):  # multitype geometry e.g. idx is {0: [1, 2]}
-                idx, indices_subgeoms = list(idx.items())[0]
+                idx, indices_subgeoms = next(iter(idx.items()))
+                geometry = fc_copy["features"][idx]["geometry"]
                 for idx_subgeom in indices_subgeoms:
                     if not isinstance(idx_subgeom, int):
                         raise TypeError(
                             "Fixing Multigeometries within Multigeometries not supported."
                         )
-                    subgeom = shape(fc_copy["features"][idx]["geometry"]).geoms[
-                        idx_subgeom
-                    ]
-                    subgeom_fixed = apply_fix(criterium, subgeom)
-                    fc_copy["features"][idx]["geometry"][
-                        idx_subgeom
-                    ] = subgeom_fixed.__geo_interface__
+                    if geometry["type"] == "GeometryCollection":
+                        subgeometry = geometry["geometries"][idx_subgeom]
+                    else:  # e.g. MultiPolygon -> Polygon
+                        subgeometry = {
+                            "type": geometry["type"].replace("Multi", ""),
+                            "coordinates": geometry["coordinates"][idx_subgeom],
+                        }
+                    fixed = fix_single_geometry(subgeometry, criterium)
+                    if fixed is None:
+                        continue
+                    if geometry["type"] == "GeometryCollection":
+                        geometry["geometries"][idx_subgeom] = fixed
+                    else:
+                        geometry["coordinates"][idx_subgeom] = fixed["coordinates"]
 
     return fc_copy

--- a/geojson_validator/main.py
+++ b/geojson_validator/main.py
@@ -72,11 +72,23 @@ def validate_geometries(
 
 def fix_geometries(
     geojson_input: Union[dict, str, Path, Any],
-    optional=[
+    optional=(
         # "excessive_coordinate_precision",
         "duplicate_nodes",
-    ],
+    ),
 ):
+    """
+    Fix invalid geometries in the GeoJSON.
+
+    Always applies the fixes for ["unclosed", "exterior_not_ccw", "interior_not_cw"].
+
+    Args:
+        geojson_input: Input GeoJSON FeatureCollection, Feature, Geometry or filepath/url to (Geo)JSON.
+        optional: Additional, non-essential fixes, one of ["duplicate_nodes"].
+
+    Returns:
+        The GeoJSON feature collection with fixed geometries.
+    """
     criteria = [
         "unclosed",
         "exterior_not_ccw",
@@ -86,6 +98,7 @@ def fix_geometries(
         # "excessive_coordinate_precision",
         "duplicate_nodes",
     ]
+    optional = list(optional or [])
     check_criteria(optional, allowed_optional, name="optional")
 
     geometry_validation_results = validate_geometries(
@@ -94,11 +107,9 @@ def fix_geometries(
         criteria_problematic=optional,
     )
     geojson_input = input_to_geojson(geojson_input)
-    validate_structure(geojson_input)
     fc = any_geojson_to_featurecollection(geojson_input)
 
-    if optional:
-        criteria.extend(optional)
+    criteria.extend(optional)
     fixed_fc = process_fix(fc, geometry_validation_results, criteria)
     logger.info(f"Fixed geometries for criteria {criteria}")
     return fixed_fc

--- a/tests/test_fixes_utils.py
+++ b/tests/test_fixes_utils.py
@@ -1,3 +1,7 @@
+import json
+
+from shapely.geometry import shape
+
 from .context import fixes_utils
 from .fixtures import read_geojson
 
@@ -141,8 +145,44 @@ def test_process_fix_multigeom():
     fixed_fc = fixes_utils.process_fix(fc, geometry_validation_results, criteria)
     assert fixed_fc != fc
     assert len(fixed_fc["features"]) == 1
-    assert len(fixed_fc["features"][0]["geometry"]["coordinates"]) == 3
+    geometry = fixed_fc["features"][0]["geometry"]
+    assert set(geometry.keys()) == {"type", "coordinates"}
+    assert len(geometry["coordinates"]) == 3
+    # The flagged subgeometries 1 & 2 were actually rewound to counter-clockwise
+    for i in [1, 2]:
+        subgeom = shape({"type": "Polygon", "coordinates": geometry["coordinates"][i]})
+        assert subgeom.exterior.is_ccw
+    # Plain JSON types, no tuples
+    assert json.loads(json.dumps(fixed_fc)) == fixed_fc
 
 
-# def test_process_fix_multigeom_geometrycollection():
-# TODO
+def test_process_fix_geometrycollection():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {
+                    "type": "GeometryCollection",
+                    "geometries": [
+                        {"type": "Point", "coordinates": [1, 2]},
+                        {  # clockwise exterior
+                            "type": "Polygon",
+                            "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+                        },
+                    ],
+                },
+            }
+        ],
+    }
+    geometry_validation_results = {
+        "invalid": {"exterior_not_ccw": [{0: [1]}]},
+        "problematic": {},
+    }
+    fixed_fc = fixes_utils.process_fix(
+        fc, geometry_validation_results, ["exterior_not_ccw"]
+    )
+    geometries = fixed_fc["features"][0]["geometry"]["geometries"]
+    assert geometries[0] == {"type": "Point", "coordinates": [1, 2]}
+    assert shape(geometries[1]).exterior.is_ccw

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -168,3 +168,10 @@ def test_fix_invalid():
     fixed_fc = main.fix_geometries(fc)
     assert fixed_fc["type"] == "FeatureCollection"
     assert fc != fixed_fc
+
+
+@pytest.mark.parametrize("optional", [None, [], ("duplicate_nodes",)])
+def test_fix_geometries_optional_argument_types(optional):
+    fc = read_geojson("./tests/data/invalid_geometries/invalid_unclosed.geojson")
+    fixed_fc = main.fix_geometries(fc, optional=optional)
+    assert fixed_fc["type"] == "FeatureCollection"


### PR DESCRIPTION
The fix results for subgeometries of MultiPolygons/GeometryCollections were written back to a wrong key, so the coordinates ended up unchanged. Now writes them to the right place and handles GeometryCollections properly.

Also returns plain lists instead of tuples in the fixed coordinates, and `optional` now accepts None/tuple.