### PR TITLE
Check all polygon rings, reclassify inner_and_exterior_ring_intersect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Update your installation to the latest version:
 
 - Fix `fix_geometries` not applying fixes to the sub-geometries of MultiPolygons/GeometryCollections
   (results were written to a wrong key, leaving the coordinates unchanged)
+- Fix `validate_geometries` mutating the input GeoJSON (Point/LineString coordinates were rewritten in place)
+- Checks now cover all Polygon rings instead of only the exterior ring
+  (`unclosed`, `less_three_unique_nodes`, `duplicate_nodes`, `excessive_coordinate_precision`,
+  `3d_coordinates`, `outside_lat_lon_boundaries`, `crosses_antimeridian`)
+- `excessive_vertices` now counts the vertices of all rings, not only the exterior ring
+- `inner_and_exterior_ring_intersect` moved from the `invalid` to the `problematic` criteria
+  (valid GeoJSON, but invalid by the OGC Simple Features standard), and no longer flags rings
+  touching at a single point, matching [geojson-invalid-geometry](https://github.com/chrieke/geojson-invalid-geometry)
+- `excessive_coordinate_precision` now also detects coordinates in exponent notation (e.g. `1e-07`)
 - `fix_geometries` returns plain lists instead of tuples in the fixed coordinates
 - Fix `fix_geometries` `duplicate_nodes` removing meaningful collinear vertices (use `shapely.remove_repeated_points` instead of `simplify(0)`)
 - Fix `3d_coordinates` and `excessive_coordinate_precision` checks missing issues on vertices after the first two (now scan all coordinates)

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ geojson_validator.validate_structure(geojson_input, check_crs=False)
 ```
 
 Returns the reasons why the input does not conform to the GeoJSON specification.
-Also gives the line location and feature index to more quickly localize the issues. 
-Example: `{"Missing 'type' member": {"line": [4], "feature": [0]}`.
+Also gives the JSON path and feature index to more quickly localize the issues. 
+Example: `{"Missing 'type' member": {"path": ["/features/0"], "feature": [0]}}`.
 
 
 ### 2. Validate geometries 🟥
@@ -66,11 +66,11 @@ invalid and problematic criteria. You can choose to validate only specific crite
 ```python
 # Invalid according to the GeoJSON specification
 criteria_invalid = ["unclosed", "less_three_unique_nodes", "exterior_not_ccw",
-                    "interior_not_cw", "inner_and_exterior_ring_intersect"]
+                    "interior_not_cw"]
 
 # Problematic with some tools & APIs
-criteria_problematic = ["holes", "self_intersection", "duplicate_nodes", 
-                        "excessive_coordinate_precision", "excessive_vertices", 
+criteria_problematic = ["holes", "inner_and_exterior_ring_intersect", "self_intersection",
+                        "duplicate_nodes", "excessive_coordinate_precision", "excessive_vertices",
                         "3d_coordinates", "outside_lat_lon_boundaries", "crosses_antimeridian"]
 
 geojson_validator.validate_geometries(geojson, criteria_invalid, criteria_problematic)

--- a/geojson_validator/checks_invalid.py
+++ b/geojson_validator/checks_invalid.py
@@ -1,17 +1,19 @@
 from shapely.geometry import Polygon
 
+from .geometry_utils import coordinate_arrays
+
 
 def check_unclosed(geometry: dict) -> bool:
-    """Return True if the geometry is not closed (first coordinate != last coordinate)."""
+    """Return True if any ring is not closed (first coordinate != last coordinate)."""
     # This needs to check the original json string, as shapely or geopandas automatically close.
-    coords = geometry["coordinates"][0]
-    return coords[0] != coords[-1]
+    return any(ring and ring[0] != ring[-1] for ring in coordinate_arrays(geometry))
 
 
 def check_less_three_unique_nodes(geometry: dict) -> bool:
-    """Return True if there are fewer than three unique nodes in the geometry."""
-    coords = geometry["coordinates"][0]
-    return len(set(map(tuple, coords))) < 3
+    """Return True if any ring has fewer than three unique nodes."""
+    return any(
+        len(set(map(tuple, ring))) < 3 for ring in coordinate_arrays(geometry)
+    )
 
 
 def check_exterior_not_ccw(geom: Polygon) -> bool:
@@ -22,8 +24,3 @@ def check_exterior_not_ccw(geom: Polygon) -> bool:
 def check_interior_not_cw(geom: Polygon) -> bool:
     """Return True if any interior ring is counter-clockwise."""
     return any(interior.is_ccw for interior in geom.interiors)
-
-
-def check_inner_and_exterior_ring_intersect(geom: Polygon) -> bool:
-    """Return True if any interior ring intersects with the exterior ring."""
-    return any(geom.exterior.intersects(interior) for interior in geom.interiors)

--- a/geojson_validator/checks_problematic.py
+++ b/geojson_validator/checks_problematic.py
@@ -1,6 +1,8 @@
 from shapely.geometry import Polygon
 from shapely.validation import explain_validity
 
+from .geometry_utils import coordinate_arrays
+
 
 def check_holes(geom: Polygon) -> bool:
     """Return True if the geometry has holes (interior rings)."""
@@ -16,68 +18,80 @@ def check_self_intersection(geom: Polygon) -> bool:
     return self_intersection
 
 
+def check_inner_and_exterior_ring_intersect(geom: Polygon) -> bool:
+    """Return True if any interior ring intersects the exterior ring in more than a single touching point."""
+    # Rings touching at a single point are allowed, line overlaps and crossings are not.
+    shell = Polygon(geom.exterior)
+    for interior in geom.interiors:
+        intersection = geom.exterior.intersection(interior)
+        if not intersection.is_empty and intersection.geom_type != "Point":
+            return True
+        # A hole touching at a single point but lying outside the shell is not acceptable.
+        if not shell.covers(interior):
+            return True
+    return False
+
+
 def check_duplicate_nodes(geometry: dict) -> bool:
     """Return True if there are duplicate nodes, excluding the acceptable duplicate of a closed ring."""
-    coords = geometry["coordinates"][0]
-    unique_coords = set(map(tuple, coords))
-
-    has_duplicates = len(unique_coords) < len(coords)
-    is_closed_ring = coords[0] == coords[-1]
-    only_closed_ring_duplicate = (
-        is_closed_ring and len(unique_coords) == len(coords) - 1
-    )
-
-    return has_duplicates and not only_closed_ring_duplicate
+    for coords in coordinate_arrays(geometry):
+        if not coords:
+            continue
+        unique_coords = set(map(tuple, coords))
+        has_duplicates = len(unique_coords) < len(coords)
+        is_closed_ring = coords[0] == coords[-1]
+        only_closed_ring_duplicate = (
+            is_closed_ring and len(unique_coords) == len(coords) - 1
+        )
+        if has_duplicates and not only_closed_ring_duplicate:
+            return True
+    return False
 
 
 def check_excessive_coordinate_precision(geometry: dict, precision=6) -> bool:
     """Return True if any coordinate has more than `precision` decimal places."""
-    for coord_xy in geometry["coordinates"][0]:
-        for coord in coord_xy:
-            splits = str(coord).split(".")
-            if (
-                len(splits) == 2 and len(splits[1]) > precision
-            ):  # catch coord without after comma
-                return True
-    return False
+    return any(
+        round(value, precision) != value
+        for coords in coordinate_arrays(geometry)
+        for position in coords
+        for value in position
+    )
 
 
 def check_excessive_vertices(
     geometry: dict,
 ) -> bool:
-    """Return True if geometry has more than 999 vertices"""
-    return len(geometry["coordinates"][0]) > 999
+    """Return True if geometry has more than 999 vertices in total"""
+    return sum(len(coords) for coords in coordinate_arrays(geometry)) > 999
 
 
 def check_3d_coordinates(geometry: dict) -> bool:
     """Return True if any coordinate is more than 2D."""
-    for coords in geometry["coordinates"][0]:
-        if len(coords) > 2:
-            return True
-    return False
+    return any(
+        len(position) > 2
+        for coords in coordinate_arrays(geometry)
+        for position in coords
+    )
 
 
 def check_outside_lat_lon_boundaries(geometry: dict) -> bool:
     """Return True if not all coordinates are within the standard lat/lon boundaries."""
-
-    def _inside_boundaries(lon, lat):
-        return -180 <= lon <= 180 and -90 <= lat <= 90
-
-    for coords in geometry["coordinates"][0]:
-        if not _inside_boundaries(coords[0], coords[1]):
-            return True
-    return False
+    return not all(
+        -180 <= position[0] <= 180 and -90 <= position[1] <= 90
+        for coords in coordinate_arrays(geometry)
+        for position in coords
+    )
 
 
 def check_crosses_antimeridian(geometry: dict) -> bool:
     """Return True if the geometry crosses the antimeridian (meridian at 180 longitude)."""
-    coords = geometry["coordinates"][0]
-    for start, end in zip(coords, coords[1:]):
-        # Normalize longitudes to -180 to 180 range
-        norm_start_lon = (start[0] + 180) % 360 - 180
-        norm_end_lon = (end[0] + 180) % 360 - 180
+    for coords in coordinate_arrays(geometry):
+        for start, end in zip(coords, coords[1:]):
+            # Normalize longitudes to -180 to 180 range
+            norm_start_lon = (start[0] + 180) % 360 - 180
+            norm_end_lon = (end[0] + 180) % 360 - 180
 
-        # Check for longitude switch indicating crossing
-        if abs(norm_end_lon - norm_start_lon) > 180:
-            return True
+            # Check for longitude switch indicating crossing
+            if abs(norm_end_lon - norm_start_lon) > 180:
+                return True
     return False

--- a/geojson_validator/geometry_utils.py
+++ b/geojson_validator/geometry_utils.py
@@ -84,22 +84,27 @@ def extract_single_geometries(geometry, geometry_type):
         return geometry["geometries"]
 
 
-def prepare_geometries_for_checks(geometry):
-    """Prepares the Geometries for the validation checks"""
+def coordinate_arrays(geometry: dict) -> list:
+    """
+    The position arrays of a single geometry, without modifying it:
+    all rings for a Polygon, one array for a LineString or Point.
+    """
+    geometry_type = geometry.get("type", None)
+    if geometry_type == "Point":
+        return [[geometry["coordinates"]]]
+    if geometry_type == "LineString":
+        return [geometry["coordinates"]]
+    return geometry["coordinates"]
+
+
+def to_shapely_or_none(geometry: dict):
+    """Parses the geometry dict to shapely for the validation checks that require it."""
     # Some criteria require the original json geometry dict as shapely etc. autofixes (e.g. closes) geometries.
     # Initiating the shapely type in each check function specifically is time intensive.
     try:
-        shapely_geom = shape(geometry)
+        return shape(geometry)
     except (TypeError, ValueError):
         # e.g. mixed 2D/3D coordinates make shapely raise. Return None so the raw-JSON
         # based checks (3d_coordinates, precision, etc.) can still run; shapely-based
         # checks are skipped for this geometry.
-        shapely_geom = None
-    # To avoid adjusting the checks code for each geometry type, they are brought to the same
-    # list depth (not ideal but okay).
-    geometry_type = geometry.get("type", None)
-    if geometry_type == "Point":
-        geometry["coordinates"] = [[geometry["coordinates"]]]
-    if geometry_type == "LineString":
-        geometry["coordinates"] = [geometry["coordinates"]]
-    return geometry, shapely_geom
+        return None

--- a/geojson_validator/geometry_validation.py
+++ b/geojson_validator/geometry_validation.py
@@ -4,7 +4,7 @@ from collections import Counter
 from loguru import logger
 
 from . import checks_invalid, checks_problematic
-from .geometry_utils import prepare_geometries_for_checks, extract_single_geometries
+from .geometry_utils import to_shapely_or_none, extract_single_geometries
 
 ALL_ACCEPTED_GEOMETRY_TYPES = POI, MPOI, LS, MLS, POL, MPOL, GC = [
     "Point",
@@ -31,14 +31,16 @@ VALIDATION_CRITERIA = {
             "relevant": [POL],
             "input": "shapely_geom",
         },
-        "inner_and_exterior_ring_intersect": {
-            "relevant": [POL],
-            "input": "shapely_geom",
-        },
         # "zero-length": {"relevant": ["LineString"], "input": "json_geometry"},
     },
     "problematic": {
         "holes": {"relevant": [POL], "input": "shapely_geom"},
+        # Valid by the GeoJSON specification, but invalid by the OGC Simple Features standard
+        # which many tools follow.
+        "inner_and_exterior_ring_intersect": {
+            "relevant": [POL],
+            "input": "shapely_geom",
+        },
         "self_intersection": {
             "relevant": [POL],
             "input": "shapely_geom",
@@ -148,7 +150,7 @@ def process_validation(geometries, criteria_invalid, criteria_problematic):
             continue
 
         # Handle Single-Geometries
-        geometry, shapely_geom = prepare_geometries_for_checks(geometry)
+        shapely_geom = to_shapely_or_none(geometry)
         if criteria_invalid:
             for criterium in criteria_invalid:
                 if apply_check(

--- a/geojson_validator/main.py
+++ b/geojson_validator/main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, List, Tuple, Any
+from typing import Dict, Union, List, Any
 import sys
 from pathlib import Path
 
@@ -23,11 +23,18 @@ logger.add(sink=sys.stderr, format=logger_format, level="INFO")
 
 def validate_structure(
     geojson_input: Union[dict, str, Path, Any], check_crs: bool = False
-) -> Tuple[bool, Union[str, None]]:
+) -> Dict:
     """
-    Returns (True, None) if the input geojson conforms to the geojson json schema v7,
-    and (False, "reason") if not.
-    Enhances error messages by specifying which elements failed validation.
+    Validate that the input conforms to the GeoJSON json schema.
+
+    Args:
+        geojson_input: Input GeoJSON FeatureCollection, Feature, Geometry or filepath/url to (Geo)JSON.
+        check_crs: Also flag a crs member, which the GeoJSON specification disallows.
+
+    Returns:
+        A dictionary of error messages with the affected json paths and feature indices, e.g.
+        {"Missing 'type' member": {"path": ["/features/0"], "feature": [0]}}.
+        Empty if the structure is valid.
     """
     geojson_data = input_to_geojson(geojson_input)
     errors = GeoJsonLint(check_crs=check_crs).lint(geojson_data)
@@ -101,12 +108,12 @@ def fix_geometries(
     optional = list(optional or [])
     check_criteria(optional, allowed_optional, name="optional")
 
+    geojson_input = input_to_geojson(geojson_input)
     geometry_validation_results = validate_geometries(
         geojson_input,
         criteria_invalid=criteria,
         criteria_problematic=optional,
     )
-    geojson_input = input_to_geojson(geojson_input)
     fc = any_geojson_to_featurecollection(geojson_input)
 
     criteria.extend(optional)

--- a/geojson_validator/schema_validation.py
+++ b/geojson_validator/schema_validation.py
@@ -34,7 +34,6 @@ class GeoJsonLint:
     def __init__(self, check_crs: bool = False):
         self.check_crs = check_crs
         self.feature_idx = None
-        self.line_map = None
         self.errors = {}
 
     def lint(self, geojson_data: Union[dict, Any]):

--- a/tests/test_checks_invalid.py
+++ b/tests/test_checks_invalid.py
@@ -20,6 +20,25 @@ def test_check_unclosed(valid_geometry):
     assert not checks_invalid.check_unclosed(valid_geometry)
 
 
+def test_check_unclosed_interior_ring():
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [
+            [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],
+            [[1, 1], [2, 1], [2, 2], [1, 2]],  # unclosed hole
+        ],
+    }
+    assert checks_invalid.check_unclosed(geometry)
+
+
+def test_check_unclosed_empty_ring():
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]], []],
+    }
+    assert not checks_invalid.check_unclosed(geometry)
+
+
 def test_less_three_unique_nodes(valid_geometry):
     geometry = read_geojson(
         "./tests/data/invalid_geometries/invalid_less_three_unique_nodes.geojson",
@@ -47,15 +66,3 @@ def test_check_interior_not_cw(valid_geometry):
     geom = shape(geometry)
     assert checks_invalid.check_interior_not_cw(geom)
     assert not checks_invalid.check_interior_not_cw(shape(valid_geometry))
-
-
-def test_check_inner_and_exterior_ring_intersect(valid_geometry):
-    geometry = read_geojson(
-        "./tests/data/invalid_geometries/invalid_inner_and_exterior_ring_intersect.geojson",
-        geometries=True,
-    )
-    geom = shape(geometry)
-    assert checks_invalid.check_inner_and_exterior_ring_intersect(geom)
-    assert not checks_invalid.check_inner_and_exterior_ring_intersect(
-        shape(valid_geometry)
-    )

--- a/tests/test_checks_problematic.py
+++ b/tests/test_checks_problematic.py
@@ -31,6 +31,41 @@ def test_check_self_intersection():
     assert problematic
 
 
+def test_check_inner_and_exterior_ring_intersect(valid_geometry):
+    geometry = read_geojson(
+        "./tests/data/invalid_geometries/invalid_inner_and_exterior_ring_intersect.geojson",
+        geometries=True,
+    )
+    assert checks_problematic.check_inner_and_exterior_ring_intersect(shape(geometry))
+    assert not checks_problematic.check_inner_and_exterior_ring_intersect(
+        shape(valid_geometry)
+    )
+
+
+def test_check_inner_and_exterior_ring_touching_at_single_point_allowed():
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [
+            [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],
+            [[0, 5], [2, 4], [2, 6], [0, 5]],  # touches the exterior only at (0, 5)
+        ],
+    }
+    assert not checks_problematic.check_inner_and_exterior_ring_intersect(
+        shape(geometry)
+    )
+
+
+def test_check_inner_ring_outside_exterior_touching_at_single_point():
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [
+            [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],
+            [[10, 5], [12, 6], [12, 4], [10, 5]],  # hole lies outside the exterior
+        ],
+    }
+    assert checks_problematic.check_inner_and_exterior_ring_intersect(shape(geometry))
+
+
 def test_check_duplicate_nodes(valid_geometry):
     geometry = read_geojson(
         "./tests/data/problematic_geometries/problematic_duplicate_nodes.geojson",
@@ -38,6 +73,14 @@ def test_check_duplicate_nodes(valid_geometry):
     )
     assert checks_problematic.check_duplicate_nodes(geometry)
     assert not checks_problematic.check_duplicate_nodes(valid_geometry)
+
+
+def test_check_duplicate_nodes_empty_ring():
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]], []],
+    }
+    assert not checks_problematic.check_duplicate_nodes(geometry)
 
 
 def test_check_excessive_coordinate_precision():
@@ -67,6 +110,22 @@ def test_check_excessive_coordinate_precision_on_later_vertex():
         ],
     }
     assert checks_problematic.check_excessive_coordinate_precision(geometry)
+
+
+def test_check_excessive_coordinate_precision_interior_ring_and_exponent():
+    # Excessive precision only in the hole; must still be detected (not just exterior ring).
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [
+            [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],
+            [[1, 1], [2, 1], [2, 2.1234567], [1, 2], [1, 1]],
+        ],
+    }
+    assert checks_problematic.check_excessive_coordinate_precision(geometry)
+    # Exponent notation (1e-07 = 0.0000001, 7 decimal places)
+    assert checks_problematic.check_excessive_coordinate_precision(
+        {"type": "Point", "coordinates": [1e-07, 0.0]}
+    )
 
 
 def test_check_excessive_vertices():

--- a/tests/test_geometry_utils.py
+++ b/tests/test_geometry_utils.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from shapely.geometry import shape, Point, LineString
+from shapely.geometry import shape, Point
 
 from .context import geometry_utils
 from .fixtures import read_geojson
@@ -53,18 +53,31 @@ def test_any_geojson_to_featurecollection_invalid_geojson_type():
         geometry_utils.any_geojson_to_featurecollection({"type": "InvalidGeoJSONType"})
 
 
-def test_prepare_geometries_for_checks():
+def test_coordinate_arrays():
     point_geojson = {"type": "Point", "coordinates": [10, 20]}
-    modified_point, shapely_point = geometry_utils.prepare_geometries_for_checks(
-        point_geojson
-    )
-    assert modified_point["coordinates"] == [[[10, 20]]]
-    assert isinstance(shapely_point, Point)
+    assert geometry_utils.coordinate_arrays(point_geojson) == [[[10, 20]]]
+    # Does not modify the input geometry
+    assert point_geojson["coordinates"] == [10, 20]
 
     linestring_geojson = {"type": "LineString", "coordinates": [[10, 20], [30, 40]]}
-    (
-        modified_linestring,
-        shapely_linestring,
-    ) = geometry_utils.prepare_geometries_for_checks(linestring_geojson)
-    assert modified_linestring["coordinates"] == [[[10, 20], [30, 40]]]
-    assert isinstance(shapely_linestring, LineString)
+    assert geometry_utils.coordinate_arrays(linestring_geojson) == [[[10, 20], [30, 40]]]
+
+    polygon_coordinates = [
+        [[0, 0], [10, 0], [10, 10], [0, 0]],
+        [[1, 1], [2, 1], [2, 2], [1, 1]],
+    ]
+    polygon_geojson = {"type": "Polygon", "coordinates": polygon_coordinates}
+    assert geometry_utils.coordinate_arrays(polygon_geojson) == polygon_coordinates
+
+
+def test_to_shapely_or_none():
+    shapely_point = geometry_utils.to_shapely_or_none(
+        {"type": "Point", "coordinates": [10, 20]}
+    )
+    assert isinstance(shapely_point, Point)
+
+    mixed_dimensions = {
+        "type": "Polygon",
+        "coordinates": [[[0, 0], [1, 0], [1, 1, 5], [0, 1], [0, 0]]],
+    }
+    assert geometry_utils.to_shapely_or_none(mixed_dimensions) is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import copy
 from unittest.mock import patch
 
 import pytest
@@ -84,6 +85,27 @@ def test_validate_geometries_invalid_no_invalid_or_problematic_checks():
     result = main.validate_geometries(fc, criteria_invalid=[])
     assert not result["invalid"]
     assert not result["problematic"]
+
+
+def test_validate_geometries_does_not_mutate_input():
+    fc = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+            },
+            {
+                "type": "Feature",
+                "properties": {},
+                "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+            },
+        ],
+    }
+    fc_before = copy.deepcopy(fc)
+    main.validate_geometries(fc)
+    assert fc == fc_before
 
 
 def test_validate__geometries_valid():


### PR DESCRIPTION
Most of the json-based checks only looked at the exterior ring. Adds a small `coordinate_arrays` helper and runs unclosed, less_three_unique_nodes, duplicate_nodes, excessive_coordinate_precision, 3d_coordinates, outside_lat_lon_boundaries and crosses_antimeridian on all rings. `excessive_vertices` now counts all rings, and the precision check also catches exponent notation like `1e-07`.

`inner_and_exterior_ring_intersect` moves from invalid to problematic (valid GeoJSON, just invalid by OGC Simple Features) and no longer flags rings touching at a single point, matching [geojson-invalid-geometry](https://github.com/chrieke/geojson-invalid-geometry).

Also fixes `validate_geometries` mutating the input (Point/LineString coordinates were rewritten in place) and some stale docs.

Stacked on #23.