### PR TITLE
Add type hints and ship a py.typed marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Update your installation to the latest version:
 
 ## Unreleased
 
+- Ship a `py.typed` marker (PEP 561), so type checkers use the annotations instead of treating the
+  package as untyped
+- Fix incorrect type hints: `criteria_invalid`/`criteria_problematic` were annotated `List[str]` but
+  defaulted to a dict (now the `INVALID_CRITERIA`/`PROBLEMATIC_CRITERIA` tuples of criteria names),
+  `validate_geometries` documented the wrong return value, and `fix_geometries` and
+  `configure_logging` were unannotated. The package now type checks cleanly (`make typecheck`)
+- Passing a single criteria string instead of a list raises a clear error instead of validating
+  against the individual characters
 - Fix `fix_geometries` not applying fixes to the sub-geometries of MultiPolygons/GeometryCollections
   (results were written to a wrong key, leaving the coordinates unchanged)
 - Fix `validate_geometries` mutating the input GeoJSON (Point/LineString coordinates were rewritten in place)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
 SRC := .
 
-test:
+test: typecheck
 	@echo "Formatting with black ..."
 	black .
 	@echo "Running tests with pytest"
 	python -m pytest --pylint --pylint-rcfile=../pylintrc
+
+typecheck:
+	@echo "Type checking with mypy ..."
+	python -m mypy
 
 redownload-testfiles:
 	@echo "Redownloading test files from https://github.com/chrieke/geojson-invalid-geometry"

--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ The result is a GeoJSON FeatureCollection with the fixed geometries.
 pydantic error messages a bit convulted (if one coordinate is missing error 4 times), very schema like, not custom, not easy to understand for no nprogrammers.
 often would need to be translated.
 - Too many logging messages, can I disable them? You can disable or configure the logging behavior via `geojson_validator.configure_logging(enabled=True, level="DEBUG")` which also returns the logger instance.
+- Does it ship type hints? Yes, the package is [PEP 561](https://peps.python.org/pep-0561/) typed, so mypy/pyright pick up the annotations without extra stubs.

--- a/geojson_validator/__init__.py
+++ b/geojson_validator/__init__.py
@@ -1,1 +1,13 @@
-from .main import validate_structure, validate_geometries, fix_geometries, configure_logging
+from .main import (
+    validate_structure,
+    validate_geometries,
+    fix_geometries,
+    configure_logging,
+)
+
+__all__ = [
+    "validate_structure",
+    "validate_geometries",
+    "fix_geometries",
+    "configure_logging",
+]

--- a/geojson_validator/checks_invalid.py
+++ b/geojson_validator/checks_invalid.py
@@ -11,9 +11,7 @@ def check_unclosed(geometry: dict) -> bool:
 
 def check_less_three_unique_nodes(geometry: dict) -> bool:
     """Return True if any ring has fewer than three unique nodes."""
-    return any(
-        len(set(map(tuple, ring))) < 3 for ring in coordinate_arrays(geometry)
-    )
+    return any(len(set(map(tuple, ring))) < 3 for ring in coordinate_arrays(geometry))
 
 
 def check_exterior_not_ccw(geom: Polygon) -> bool:

--- a/geojson_validator/checks_problematic.py
+++ b/geojson_validator/checks_problematic.py
@@ -48,7 +48,7 @@ def check_duplicate_nodes(geometry: dict) -> bool:
     return False
 
 
-def check_excessive_coordinate_precision(geometry: dict, precision=6) -> bool:
+def check_excessive_coordinate_precision(geometry: dict, precision: int = 6) -> bool:
     """Return True if any coordinate has more than `precision` decimal places."""
     return any(
         round(value, precision) != value

--- a/geojson_validator/fixes.py
+++ b/geojson_validator/fixes.py
@@ -5,24 +5,24 @@ from shapely.geometry.polygon import orient
 
 # Needs manual check: check_less_three_unique_nodes
 # Possible but problematic: check_outside_lat_lon_boundaries, check_inner_and_exterior_ring_intersect
-def fix_unclosed(geom: Polygon):
+def fix_unclosed(geom: Polygon) -> Polygon:
     """Close the geometry by adding the first coordinate at the end if not closed."""
     # Constructing a shapely Polygon already closes the ring, so by the time a geometry
     # reaches this function it is closed. Kept for explicit, name-based fix dispatch.
     return geom
 
 
-def fix_exterior_not_ccw(geom: Polygon):
+def fix_exterior_not_ccw(geom: Polygon) -> Polygon:
     """Orient the polygon to the GeoJSON right-hand rule (exterior CCW, interiors CW)."""
     return orient(geom, sign=1.0)
 
 
-def fix_interior_not_cw(geom: Polygon):
+def fix_interior_not_cw(geom: Polygon) -> Polygon:
     """Orient the polygon to the GeoJSON right-hand rule (exterior CCW, interiors CW)."""
     return orient(geom, sign=1.0)
 
 
-def fix_duplicate_nodes(geom: Polygon):
+def fix_duplicate_nodes(geom: Polygon) -> Polygon:
     """Remove consecutive duplicate nodes, preserving meaningful (collinear) vertices."""
     # shapely.remove_repeated_points only drops repeated points; unlike simplify(0) it does
     # not collapse collinear vertices.

--- a/geojson_validator/fixes_utils.py
+++ b/geojson_validator/fixes_utils.py
@@ -1,20 +1,21 @@
-from typing import List, Union
+from typing import Any, Dict, Sequence, Union
 import copy
 
 from shapely.geometry import shape
+from shapely.geometry.base import BaseGeometry
 from loguru import logger
 
 
 from . import fixes
 
 
-def apply_fix(criterium: str, shapely_geom):
+def apply_fix(criterium: str, shapely_geom: BaseGeometry) -> BaseGeometry:
     """Applies the correct fix for the criteria"""
     fix_func = getattr(fixes, f"fix_{criterium}")
     return fix_func(shapely_geom)
 
 
-def deep_list(obj):
+def deep_list(obj: Any) -> Any:
     """Converts nested coordinate tuples (e.g. from __geo_interface__) to plain JSON-style lists."""
     if isinstance(obj, dict):
         return {key: deep_list(value) for key, value in obj.items()}
@@ -36,7 +37,9 @@ def fix_single_geometry(geometry: dict, criterium: str) -> Union[dict, None]:
     return deep_list(apply_fix(criterium, geom).__geo_interface__)
 
 
-def process_fix(fc, geometry_validation_results: dict, criteria: List[str]):
+def process_fix(
+    fc: dict, geometry_validation_results: Dict[str, Any], criteria: Sequence[str]
+) -> Dict[str, Any]:
     fc_copy = copy.deepcopy(fc)
     for criterium in criteria:
         if criterium in geometry_validation_results["invalid"]:

--- a/geojson_validator/geometry_utils.py
+++ b/geojson_validator/geometry_utils.py
@@ -1,13 +1,14 @@
-from typing import Union, Any
+from typing import Any, List, Optional, Union
 from urllib.parse import urlparse
 from pathlib import Path
 import json
 
 from shapely.geometry import shape
+from shapely.geometry.base import BaseGeometry
 import requests
 
 
-def read_geojson_file_or_url(fp_or_url: Union[str, Path]):
+def read_geojson_file_or_url(fp_or_url: Union[str, Path]) -> dict:
     """Reads a geojson source from a filepath or url"""
     if Path(fp_or_url).suffix not in [
         ".json",
@@ -25,15 +26,15 @@ def read_geojson_file_or_url(fp_or_url: Union[str, Path]):
         return json.load(f)
 
 
-def input_to_geojson(geojson_input: Union[str, Path, dict, Any]) -> dict:
+def input_to_geojson(geojson_input: Any) -> dict:
     """Take the input which can be various types and reads/transforms it to Geojson"""
     if isinstance(geojson_input, (str, Path)):
-        geojson_input = read_geojson_file_or_url(geojson_input)
-    elif hasattr(
+        return read_geojson_file_or_url(geojson_input)
+    if hasattr(
         geojson_input, "__geo_interface__"
     ):  # e.g. shapely geometry object, geojson library objects
-        geojson_input = geojson_input.__geo_interface__
-    elif not isinstance(geojson_input, (dict)) or "type" not in geojson_input:
+        return geojson_input.__geo_interface__
+    if not isinstance(geojson_input, dict) or "type" not in geojson_input:
         raise ValueError(
             f"Unsupported input '{type(geojson_input)}'. Input must be a GeoJSON, filepath/url to GeoJSON, "
             f"shapely geometry or any object with a __geo_interface__"
@@ -41,9 +42,7 @@ def input_to_geojson(geojson_input: Union[str, Path, dict, Any]) -> dict:
     return geojson_input
 
 
-def any_geojson_to_featurecollection(
-    geojson_input: Union[str, Path, dict, Any]
-) -> dict:
+def any_geojson_to_featurecollection(geojson_input: dict) -> dict:
     """Take a geojson of various types (Feature, Geometry, Fc) and transform it to a featurecollection"""
     supported_geojson_types = [
         "Point",
@@ -74,14 +73,15 @@ def any_geojson_to_featurecollection(
     return fc
 
 
-def extract_single_geometries(geometry, geometry_type):
+def extract_single_geometries(geometry: dict, geometry_type: str) -> List[dict]:
     if "Multi" in geometry_type:
         single_type = geometry_type.split("Multi")[1]
         return [
             {"type": single_type, "coordinates": g} for g in geometry["coordinates"]
         ]
-    elif geometry_type == "GeometryCollection":
+    if geometry_type == "GeometryCollection":
         return geometry["geometries"]
+    return []
 
 
 def coordinate_arrays(geometry: dict) -> list:
@@ -97,7 +97,7 @@ def coordinate_arrays(geometry: dict) -> list:
     return geometry["coordinates"]
 
 
-def to_shapely_or_none(geometry: dict):
+def to_shapely_or_none(geometry: dict) -> Optional[BaseGeometry]:
     """Parses the geometry dict to shapely for the validation checks that require it."""
     # Some criteria require the original json geometry dict as shapely etc. autofixes (e.g. closes) geometries.
     # Initiating the shapely type in each check function specifically is time intensive.

--- a/geojson_validator/geometry_validation.py
+++ b/geojson_validator/geometry_validation.py
@@ -1,7 +1,8 @@
-from typing import List
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from collections import Counter
 
 from loguru import logger
+from shapely.geometry.base import BaseGeometry
 
 from . import checks_invalid, checks_problematic
 from .geometry_utils import to_shapely_or_none, extract_single_geometries
@@ -16,7 +17,7 @@ ALL_ACCEPTED_GEOMETRY_TYPES = POI, MPOI, LS, MLS, POL, MPOL, GC = [
     "GeometryCollection",
 ]
 
-VALIDATION_CRITERIA = {
+VALIDATION_CRITERIA: Dict[str, Dict[str, Dict[str, Any]]] = {
     "invalid": {
         "unclosed": {"relevant": [POL], "input": "json_geometry"},
         "less_three_unique_nodes": {
@@ -73,10 +74,17 @@ VALIDATION_CRITERIA = {
     },
 }
 
+INVALID_CRITERIA: Tuple[str, ...] = tuple(VALIDATION_CRITERIA["invalid"])
+PROBLEMATIC_CRITERIA: Tuple[str, ...] = tuple(VALIDATION_CRITERIA["problematic"])
+
 
 def check_criteria(
-    selected_criteria: List[str], allowed_criteria: List[str], name: str
-):
+    selected_criteria: Sequence[str], allowed_criteria: Sequence[str], name: str
+) -> None:
+    if isinstance(selected_criteria, str):
+        raise ValueError(
+            f"`{name}` must be a list of criteria names, not the single string '{selected_criteria}'"
+        )
     if selected_criteria:
         for criterium in selected_criteria:
             if criterium not in allowed_criteria:
@@ -87,8 +95,12 @@ def check_criteria(
 
 
 def apply_check(
-    criterium, single_geometry, shapely_geom, geometry_type, criteria_type="invalid"
-):
+    criterium: str,
+    single_geometry: dict,
+    shapely_geom: Optional[BaseGeometry],
+    geometry_type: str,
+    criteria_type: str = "invalid",
+) -> Optional[bool]:
     """Applies the correct check for the criteria. Only accepts single geometries."""
     geometry_input_options = {
         "json_geometry": single_geometry,
@@ -107,12 +119,18 @@ def apply_check(
         )
         check_func = getattr(check_module, f"check_{criterium}")
         return check_func(geometry_input_options[required_input_type])
+    return None
 
 
-def process_validation(geometries, criteria_invalid, criteria_problematic):
-    results_invalid, results_problematic = {}, {}
-    skipped_validation = []
-    geometry_types = []
+def process_validation(
+    geometries: Sequence[Optional[dict]],
+    criteria_invalid: Sequence[str],
+    criteria_problematic: Sequence[str],
+) -> Dict[str, Any]:
+    results_invalid: Dict[str, List[Any]] = {}
+    results_problematic: Dict[str, List[Any]] = {}
+    skipped_validation: List[int] = []
+    geometry_types: List[Optional[str]] = []
 
     for i, geometry in enumerate(geometries):
         if geometry is None:

--- a/geojson_validator/main.py
+++ b/geojson_validator/main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, List, Any
+from typing import Any, Dict, Sequence, Union, TYPE_CHECKING
 import sys
 from pathlib import Path
 
@@ -10,11 +10,15 @@ from .geometry_utils import (
     any_geojson_to_featurecollection,
 )
 from .geometry_validation import (
-    VALIDATION_CRITERIA,
+    INVALID_CRITERIA,
+    PROBLEMATIC_CRITERIA,
     check_criteria,
     process_validation,
 )
 from .fixes_utils import process_fix
+
+if TYPE_CHECKING:
+    from loguru import Logger
 
 logger.remove()
 logger_format = "{time:YYYY-MM-DD_HH:mm:ss.SSS} | {message}"
@@ -23,7 +27,7 @@ logger.add(sink=sys.stderr, format=logger_format, level="INFO")
 
 def validate_structure(
     geojson_input: Union[dict, str, Path, Any], check_crs: bool = False
-) -> Dict:
+) -> Dict[str, Any]:
     """
     Validate that the input conforms to the GeoJSON json schema.
 
@@ -43,29 +47,28 @@ def validate_structure(
 
 
 def validate_geometries(
-    geojson_input: Union[dict, str, Path],
-    criteria_invalid: List[str] = VALIDATION_CRITERIA["invalid"],
-    criteria_problematic: List[str] = VALIDATION_CRITERIA["problematic"],
-) -> Dict:
+    geojson_input: Union[dict, str, Path, Any],
+    criteria_invalid: Sequence[str] = INVALID_CRITERIA,
+    criteria_problematic: Sequence[str] = PROBLEMATIC_CRITERIA,
+) -> Dict[str, Any]:
     """
     Validate that a GeoJSON conforms to the geojson specs.
 
     Args:
-        geojson: Input GeoJSON FeatureCollection, Feature, Geometry or filepath to (Geo)JSON/file.
+        geojson_input: Input GeoJSON FeatureCollection, Feature, Geometry or filepath/url to (Geo)JSON.
         criteria_invalid: A list of validation criteria that are invalid according the GeoJSON specification.
         criteria_problematic: A list of validation criteria that are valid, but problematic with some tools.
 
     Returns:
-        The validated & fixed GeoJSON feature collection.
+        A dictionary with the violated criteria and the affected feature indices, e.g.
+        {"invalid": {"unclosed": [0]}, "problematic": {}, ...}.
     """
     if not criteria_invalid and not criteria_problematic:
         raise ValueError(
             "Select at least one criteria in `criteria_invalid` or `criteria_problematic`"
         )
-    check_criteria(criteria_invalid, VALIDATION_CRITERIA["invalid"], name="invalid")
-    check_criteria(
-        criteria_problematic, VALIDATION_CRITERIA["problematic"], name="problematic"
-    )
+    check_criteria(criteria_invalid, INVALID_CRITERIA, name="invalid")
+    check_criteria(criteria_problematic, PROBLEMATIC_CRITERIA, name="problematic")
 
     geojson_input = input_to_geojson(geojson_input)
     fc = any_geojson_to_featurecollection(geojson_input)
@@ -79,11 +82,11 @@ def validate_geometries(
 
 def fix_geometries(
     geojson_input: Union[dict, str, Path, Any],
-    optional=(
+    optional: Sequence[str] = (
         # "excessive_coordinate_precision",
         "duplicate_nodes",
     ),
-):
+) -> Dict[str, Any]:
     """
     Fix invalid geometries in the GeoJSON.
 
@@ -105,8 +108,8 @@ def fix_geometries(
         # "excessive_coordinate_precision",
         "duplicate_nodes",
     ]
-    optional = list(optional or [])
     check_criteria(optional, allowed_optional, name="optional")
+    optional = list(optional or [])
 
     geojson_input = input_to_geojson(geojson_input)
     geometry_validation_results = validate_geometries(
@@ -121,18 +124,19 @@ def fix_geometries(
     logger.info(f"Fixed geometries for criteria {criteria}")
     return fixed_fc
 
-def configure_logging(enabled=True, level="INFO"):
+
+def configure_logging(enabled: bool = True, level: str = "INFO") -> "Logger":
     """
     Configures the library logging behavior.
 
     Args:
-        enabled (bool): If False, disables all logging.
-        level (str): Logging level, e.g., 'INFO', 'DEBUG', 'WARNING', 'ERROR'.
+        enabled: If False, disables all logging.
+        level: Logging level, e.g., 'INFO', 'DEBUG', 'WARNING', 'ERROR'.
 
     Returns:
-        logger: The configured loguru logger instance.
+        The configured loguru logger instance.
     """
     logger.remove()  # Clear all existing loggers
     if enabled:
-        logger.add(sys.stderr, format="{time:YYYY-MM-DD_HH:mm:ss.SSS} | {message}", level=level)
+        logger.add(sink=sys.stderr, format=logger_format, level=level)
     return logger

--- a/geojson_validator/schema_validation.py
+++ b/geojson_validator/schema_validation.py
@@ -1,4 +1,4 @@
-from typing import List, Any, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 class GeoJsonLint:
@@ -13,7 +13,7 @@ class GeoJsonLint:
     Focuses on structural GEOJSON schema validation, not GeoJSON specification geometry rules.
     """
 
-    GEOMETRY_TYPES_DEPTHS = {
+    GEOMETRY_TYPES_DEPTHS: Dict[str, Dict[str, Any]] = {
         "Point": {"array_depth": 1, "min_max_positions": (1, 1)},
         "LineString": {"array_depth": 2, "min_max_positions": (2, None)},
         "MultiPoint": {
@@ -33,10 +33,10 @@ class GeoJsonLint:
 
     def __init__(self, check_crs: bool = False):
         self.check_crs = check_crs
-        self.feature_idx = None
-        self.errors = {}
+        self.feature_idx: Optional[int] = None
+        self.errors: Dict[str, Dict[str, List[Any]]] = {}
 
-    def lint(self, geojson_data: Union[dict, Any]):
+    def lint(self, geojson_data: Union[dict, Any]) -> Dict[str, Dict[str, List[Any]]]:
         root_path = ""
         if not isinstance(geojson_data, dict):
             self._add_error("Root of GeoJSON must be an object/dictionary", root_path)
@@ -46,7 +46,7 @@ class GeoJsonLint:
 
         return self.errors
 
-    def _add_error(self, message: str, path: str):
+    def _add_error(self, message: str, path: str) -> None:
         if message not in self.errors:
             self.errors[message] = {"path": [path]}
             if self.feature_idx is not None:
@@ -56,7 +56,7 @@ class GeoJsonLint:
             if self.feature_idx is not None:
                 self.errors[message]["feature"].append(self.feature_idx)
 
-    def _validate_geojson_root(self, obj: Union[dict, Any]):
+    def _validate_geojson_root(self, obj: Union[dict, Any]) -> None:
         """Validate that the geojson object root directory conforms to the requirements."""
         root_path = ""
         if self._is_invalid_type_property(obj, self.GEOJSON_TYPES, root_path):
@@ -72,7 +72,7 @@ class GeoJsonLint:
 
     def _validate_feature_collection(
         self, feature_collection: Union[dict, Any], path: str
-    ):
+    ) -> None:
         """Validate that the featurecollection object conforms to the requirements."""
         self._is_invalid_type_property(
             feature_collection, ["FeatureCollection"], f"{path}/type"
@@ -105,7 +105,7 @@ class GeoJsonLint:
         if bbox:
             self._validate_bbox(bbox, f"{path}/bbox")
 
-    def _validate_feature(self, feature: Union[dict, Any], path: str):
+    def _validate_feature(self, feature: Union[dict, Any], path: str) -> None:
         """Validate that the feature object conforms to the requirements."""
         self._is_invalid_type_property(feature, ["Feature"], f"{path}/type")
         if "id" in feature and not isinstance(feature["id"], (str, int)):
@@ -124,14 +124,14 @@ class GeoJsonLint:
         if bbox:
             self._validate_bbox(bbox, f"{path}/bbox")
 
-    def _validate_geometry(self, geometry: dict, path: str):
+    def _validate_geometry(self, geometry: dict, path: str) -> None:
         """Validate that the geometry object conforms to the requirements."""
         if self._is_invalid_type_property(
             geometry, self.GEOMETRY_TYPES, f"{path}/type"
         ):
             return
 
-        obj_type = geometry.get("type")
+        obj_type = geometry["type"]
         if obj_type == "GeometryCollection":
             if not self._is_invalid_property(geometry, "geometries", "array", path):
                 for idx, geom in enumerate(geometry["geometries"]):
@@ -154,18 +154,19 @@ class GeoJsonLint:
             self._validate_bbox(bbox, f"{path}/bbox")
 
     def _is_invalid_datatype(
-        self, obj: Union[dict, list, Any], required_data_type, path
-    ):
+        self, obj: Union[dict, list, Any], required_data_type: type, path: str
+    ) -> bool:
         if not isinstance(obj, required_data_type):
             self._add_error(
                 f"Object must be a '{required_data_type}', but is a {type(obj)} instead",
                 path,
             )
             return True
+        return False
 
     def _is_invalid_type_property(
         self, obj: Union[dict, Any], allowed_types: List[str], path: str
-    ):
+    ) -> bool:
         """
         Checks if an object type member conforms to the requirements.
 
@@ -190,7 +191,7 @@ class GeoJsonLint:
 
     def _is_invalid_property(
         self, obj: Union[dict, Any], property_name: str, required_type: str, path: str
-    ):
+    ) -> bool:
         """
         Checks if an object property conforms to the requirements.
 
@@ -225,8 +226,10 @@ class GeoJsonLint:
                 return True
         return False
 
-    def _is_incorrect_coordinates_depth(self, coords, obj_type, path):
-        def _determine_array_depth(array, current_depth=0):
+    def _is_incorrect_coordinates_depth(
+        self, coords: Union[list, Any], obj_type: str, path: str
+    ) -> bool:
+        def _determine_array_depth(array: Any, current_depth: int = 0) -> int:
             """Recursively determine the depth of an array."""
             if not isinstance(array, list) or not array:
                 return current_depth
@@ -245,7 +248,7 @@ class GeoJsonLint:
             return True
         return False
 
-    def _validate_position(self, coords: Union[list, Any], path: str):
+    def _validate_position(self, coords: Union[list, Any], path: str) -> None:
         """Validate that the single coordinate position conforms to the requirements."""
         if len(coords) < 2:
             self._add_error(
@@ -263,7 +266,7 @@ class GeoJsonLint:
                 path,
             )
 
-    def _validate_position_array(self, coords: Union[list, Any], path: str):
+    def _validate_position_array(self, coords: Union[list, Any], path: str) -> None:
         """Validate that the array of multiple coordinate positions conforms to the requirements."""
         # If the first element is a list, recurse further
         if len(coords) and isinstance(coords[0], list):  # avoid empty list index error
@@ -272,7 +275,7 @@ class GeoJsonLint:
         else:
             self._validate_position(coords, path)
 
-    def _validate_bbox(self, bbox: Union[list, Any], path):
+    def _validate_bbox(self, bbox: Union[list, Any], path: str) -> None:
         if not isinstance(bbox, list):
             self._add_error(
                 "'bbox' member must be a one-dimensional array with bounding box coordinates",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dev = [
     "pytest-pylint",
     "pytest-sugar",
     "mypy",
+    "types-requests",
     "grip",
     "twine",
 ]
@@ -37,6 +38,16 @@ dev = [
 [build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["geojson_validator"]
+
+[tool.setuptools.package-data]
+geojson_validator = ["py.typed"]
+
+[tool.mypy]
+files = ["geojson_validator"]
+ignore_missing_imports = true
 
 [project.urls]
 Homepage = "https://github.com/chrieke/geojson-validator"

--- a/tests/test_geometry_utils.py
+++ b/tests/test_geometry_utils.py
@@ -60,7 +60,9 @@ def test_coordinate_arrays():
     assert point_geojson["coordinates"] == [10, 20]
 
     linestring_geojson = {"type": "LineString", "coordinates": [[10, 20], [30, 40]]}
-    assert geometry_utils.coordinate_arrays(linestring_geojson) == [[[10, 20], [30, 40]]]
+    assert geometry_utils.coordinate_arrays(linestring_geojson) == [
+        [[10, 20], [30, 40]]
+    ]
 
     polygon_coordinates = [
         [[0, 0], [10, 0], [10, 10], [0, 0]],

--- a/tests/test_geometry_validation.py
+++ b/tests/test_geometry_validation.py
@@ -7,7 +7,7 @@ def test_check_criteria_invalid():
     with pytest.raises(ValueError):
         geometry_validation.check_criteria(
             ["non_existent_criteria"],
-            geometry_validation.VALIDATION_CRITERIA["invalid"],
+            geometry_validation.INVALID_CRITERIA,
             "invalid",
         )
 
@@ -16,16 +16,23 @@ def test_check_criteria_valid():
     try:
         geometry_validation.check_criteria(
             ["unclosed", "less_three_unique_nodes"],
-            geometry_validation.VALIDATION_CRITERIA["invalid"],
+            geometry_validation.INVALID_CRITERIA,
             "invalid",
         )
         geometry_validation.check_criteria(
             ["holes"],
-            geometry_validation.VALIDATION_CRITERIA["problematic"],
+            geometry_validation.PROBLEMATIC_CRITERIA,
             "problematic",
         )
     except ValueError:
         pytest.fail("Unexpected ValueError for valid criteria")
+
+
+def test_check_criteria_single_string_raises():
+    with pytest.raises(ValueError, match="must be a list of criteria names"):
+        geometry_validation.check_criteria(
+            "unclosed", geometry_validation.INVALID_CRITERIA, "invalid"
+        )
 
 
 def test_process_validation_valid_polygon_without_criteria():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,5 @@
 import copy
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +11,10 @@ from .fixtures import (
     fixture_geojson_examples_all_normal_files,
 )
 from .context import main
+
+
+def test_py_typed_marker_shipped_with_package():
+    assert (Path(main.__file__).parent / "py.typed").is_file()
 
 
 def test_validate_schema_conformity_valid():
@@ -197,3 +202,9 @@ def test_fix_geometries_optional_argument_types(optional):
     fc = read_geojson("./tests/data/invalid_geometries/invalid_unclosed.geojson")
     fixed_fc = main.fix_geometries(fc, optional=optional)
     assert fixed_fc["type"] == "FeatureCollection"
+
+
+def test_fix_geometries_optional_single_string_raises():
+    fc = read_geojson("./tests/data/invalid_geometries/invalid_unclosed.geojson")
+    with pytest.raises(ValueError, match="must be a list of criteria names"):
+        main.fix_geometries(fc, optional="duplicate_nodes")


### PR DESCRIPTION
The package was fully untyped from the outside, so mypy/pyright treated it as `Any`. This annotates the code and adds a `py.typed` marker so the annotations actually get used.

Along the way a few hints turned out to be wrong: `criteria_invalid`/`criteria_problematic` were declared `List[str]` but defaulted to the `VALIDATION_CRITERIA` dicts (now `INVALID_CRITERIA`/`PROBLEMATIC_CRITERIA` tuples), and `validate_geometries` documented the wrong return value. Passing a single criteria string now raises a clear error instead of validating against its characters.

`make typecheck` runs mypy and is wired into `make test`. Existing behaviour is unchanged; tests pass.