### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,9 @@ Update your installation to the latest version:
 - Winding-order fixes now use `shapely.geometry.polygon.orient`
 - `read_geojson_file_or_url` raises a clear HTTP error instead of silently falling through to a file open on non-200 responses
 - Logging is configured in a single module instead of three (no longer wipes the global loguru logger multiple times on import)
-- Require Python >= 3.9
+- Require Python >= 3.10 (Python 3.9 is end-of-life; the current `requests` and `shapely` releases
+  no longer support it), and bump the dependency floors to `loguru>=0.7.3`, `requests>=2.34.2`,
+  `shapely>=2.1.2`
 
 ## 0.6.0
 **November 29, 2024**

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@ SRC := .
 test: typecheck
 	@echo "Formatting with black ..."
 	black .
+	@echo "Linting with pylint ..."
+	python -m pylint --rcfile=pylintrc geojson_validator tests
 	@echo "Running tests with pytest"
-	python -m pytest --pylint --pylint-rcfile=../pylintrc
+	python -m pytest
 
 typecheck:
 	@echo "Type checking with mypy ..."

--- a/pylintrc
+++ b/pylintrc
@@ -8,7 +8,6 @@ disable=
     too-few-public-methods,
     missing-final-newline,
     too-many-boolean-expressions,
-    bad-continuation,
     invalid-name,
     super-init-not-called,
     inconsistent-return-statements,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dev = [
     "black",
     "pytest",
     "pylint",
-    "pytest-pylint",
     "pytest-sugar",
     "mypy",
     "types-requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "geojson-validator"
 version = "0.6.0"
 description = "Validates and fixes GeoJSON"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "Christoph Rieke", email = "christoph.k.rieke@gmail.com" }]
 keywords = ["geojson", "validation", "GIS"]
@@ -15,9 +15,9 @@ classifiers = [
     "Intended Audience :: Developers"
 ]
 dependencies = [
-    "loguru>=0.7.2",
-    "requests>=2.32.3",
-    "shapely>=2.0.6",
+    "loguru>=0.7.3",
+    "requests>=2.34.2",
+    "shapely>=2.1.2",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
Bumps loguru, requests and shapely to the current releases.

This raises the Python floor to 3.10, which isn't optional: the latest requests
and shapely both declare `requires-python >=3.10`, and 3.9 has been EOL since
October. Only about 0.1% of downloads are on 3.10 or below.

The dev tools were unpinned so they came along too, and two things broke:

- pytest-pylint crashes on pytest 9 (it registers `pytest_collect_file` with the
  `path` argument pytest removed), and 0.21.0 is the last release. Dropped it and
  moved pylint into the Makefile instead of pinning pytest back. The old
  invocation pointed at `../pylintrc` anyway, which is outside the repo.
- pylint 4 flags `bad-continuation` as a useless option value, so it's gone.

mypy, pylint and pytest are all clean. Also installed from source into a 3.10 venv
to check the new floor actually resolves.