### PR TITLE
Skip broken geometries instead of raising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ Update your installation to the latest version:
 - When more than one fix applies to the same geometry, a `duplicate_nodes` removal is no longer
   partly undone by the next fix re-adding a closing coordinate. Only reachable when calling
   `process_fix` directly; `fix_geometries` was unaffected
+- `validate_geometries` no longer raises on structurally broken geometries (a position with a single
+  or non-numeric value, missing `coordinates`, a geometry that is not an object). The affected
+  feature index is reported in `skipped_validation` instead; use `validate_structure` to see what is
+  wrong. A missing `geometry` member is now treated like an explicit `"geometry": null`
 
 ## 0.6.0
 **November 29, 2024**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ Update your installation to the latest version:
   or non-numeric value, missing `coordinates`, a geometry that is not an object). The affected
   feature index is reported in `skipped_validation` instead; use `validate_structure` to see what is
   wrong. A missing `geometry` member is now treated like an explicit `"geometry": null`
+- Fix a MultiType geometry or GeometryCollection with a sub-geometry that could not be checked being
+  reported as fully valid. The sub-geometry's skip was dropped, so `skipped_validation` stayed empty;
+  the index of the multi-geometry is now listed there
 
 ## 0.6.0
 **November 29, 2024**

--- a/README.md
+++ b/README.md
@@ -79,15 +79,20 @@ Returns the reasons (example below) and positional indices of the invalid geomet
 sub-geometry of a MultiType geometry make it invalid e.g. `{2:[0, 5]}`.
 
 ```
-{"invalid": 
-      {"unclosed": [0, 3],
-       "exterior_not_ccw":  [{2:[0, 5]}],  
+{"invalid":
+     {"unclosed": [0, 3],
+      "exterior_not_ccw": [{2: [0, 5]}]},
  "problematic":
-      {"crosses_antimeridian": [1]},
- "count_geometry_types": 
-      {"Polygon": 3,
-       "MultiPolygon": 1}}
+     {"crosses_antimeridian": [1]},
+ "count_geometry_types":
+     {"Polygon": 3,
+      "MultiPolygon": 1},
+ "skipped_validation": []}
 ```
+
+`skipped_validation` lists the indices of features that could not be checked, e.g. a null
+geometry, an unsupported geometry type, or a geometry whose structure is broken. Use
+`validate_structure` to find out what is wrong with those.
 
 
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ sub-geometry of a MultiType geometry make it invalid e.g. `{2:[0, 5]}`.
 
 `skipped_validation` lists the indices of features that could not be checked, e.g. a null
 geometry, an unsupported geometry type, or a geometry whose structure is broken. Use
-`validate_structure` to find out what is wrong with those.
+`validate_structure` to find out what is wrong with those. A MultiType geometry is listed
+if any of its sub-geometries could not be checked, so it can appear both here and under a
+violated criterium.
 
 
 

--- a/geojson_validator/geometry_validation.py
+++ b/geojson_validator/geometry_validation.py
@@ -167,6 +167,12 @@ def _validate(
             logger.info("Null geometry found in GeoJSON Feature, skipping.")
             skipped_validation.append(i)
             continue
+        if not isinstance(geometry, dict):
+            logger.info(
+                f"Geometry must be an object, but is a {type(geometry).__name__}, skipping."
+            )
+            skipped_validation.append(i)
+            continue
         geometry_type = geometry.get("type", None)
         geometry_types.append(geometry_type)
         if geometry_type not in ALL_ACCEPTED_GEOMETRY_TYPES:
@@ -176,44 +182,60 @@ def _validate(
             skipped_validation.append(i)  # TODO: Improve skipped_validation result
             continue
 
-        # Handle Multi-Geometries & Geometrycollections:
-        # Extract the single geometries in the multi-geometry/collection, run a separate validation on each.
-        # Output results in this style: {3: [1,2]} (fourth geometry, the multigeometry is invalid,
-        # because the second and third sub-geometries in it are invalid).
-        if "Multi" in geometry_type or geometry_type == "GeometryCollection":
-            single_geometries = extract_single_geometries(geometry, geometry_type)
-            results_multi = _validate(
-                single_geometries,
-                selected_invalid,
-                selected_problematic,
-                types_needing_shapely,
-            )
-            # Take all invalid criteria from the e.g. Polygons inside the Multipolygon and indicate them
-            # as the positional index of the MultiPolygon.
-            for criterium in results_multi["invalid"]:
-                results_invalid.setdefault(criterium, []).append(
-                    {i: results_multi["invalid"][criterium]}
+        # The value appended per flagged criterium: the geometry's own index, or
+        # {index: [sub-indices]} for a multi-geometry.
+        flagged_invalid: Dict[str, Any]
+        flagged_problematic: Dict[str, Any]
+        try:
+            if "Multi" in geometry_type or geometry_type == "GeometryCollection":
+                # Validate each single geometry inside the multi-geometry/collection
+                # separately, and report the results under the index of the
+                # multi-geometry: {3: [1, 2]} is "the fourth geometry is invalid,
+                # because its second and third sub-geometries are".
+                results_multi = _validate(
+                    extract_single_geometries(geometry, geometry_type),
+                    selected_invalid,
+                    selected_problematic,
+                    types_needing_shapely,
                 )
-            for criterium in results_multi["problematic"]:
-                results_problematic.setdefault(criterium, []).append(
-                    {i: results_multi["problematic"][criterium]}
+                flagged_invalid = {
+                    criterium: {i: indices}
+                    for criterium, indices in results_multi["invalid"].items()
+                }
+                flagged_problematic = {
+                    criterium: {i: indices}
+                    for criterium, indices in results_multi["problematic"].items()
+                }
+            else:
+                shapely_geom = (
+                    to_shapely_or_none(geometry)
+                    if geometry_type in types_needing_shapely
+                    else None
                 )
+                flagged_invalid = {
+                    criterium: i
+                    for criterium in _apply_checks(
+                        selected_invalid, geometry, shapely_geom, geometry_type
+                    )
+                }
+                flagged_problematic = {
+                    criterium: i
+                    for criterium in _apply_checks(
+                        selected_problematic, geometry, shapely_geom, geometry_type
+                    )
+                }
+        except (TypeError, IndexError, KeyError) as error:
+            # A structurally broken geometry, e.g. a position with a single or a
+            # non-numeric value, or missing coordinates. validate_structure reports what
+            # is actually wrong; here it is only skipped instead of raising.
+            logger.info(f"Geometry could not be validated ({error!r}), skipping.")
+            skipped_validation.append(i)
             continue
 
-        # Handle Single-Geometries
-        shapely_geom = (
-            to_shapely_or_none(geometry)
-            if geometry_type in types_needing_shapely
-            else None
-        )
-        for criterium in _apply_checks(
-            selected_invalid, geometry, shapely_geom, geometry_type
-        ):
-            results_invalid.setdefault(criterium, []).append(i)
-        for criterium in _apply_checks(
-            selected_problematic, geometry, shapely_geom, geometry_type
-        ):
-            results_problematic.setdefault(criterium, []).append(i)
+        for criterium, flagged in flagged_invalid.items():
+            results_invalid.setdefault(criterium, []).append(flagged)
+        for criterium, flagged in flagged_problematic.items():
+            results_problematic.setdefault(criterium, []).append(flagged)
 
     # TODO: Results format better: feature1: flaws, feature4: flaws, feature9: flaws?
     results = {

--- a/geojson_validator/geometry_validation.py
+++ b/geojson_validator/geometry_validation.py
@@ -198,6 +198,10 @@ def _validate(
                     selected_problematic,
                     types_needing_shapely,
                 )
+                # A sub-geometry that could not be checked must not pass silently, or a
+                # broken multi-geometry is indistinguishable from a valid one.
+                if results_multi["skipped_validation"]:
+                    skipped_validation.append(i)
                 flagged_invalid = {
                     criterium: {i: indices}
                     for criterium, indices in results_multi["invalid"].items()

--- a/geojson_validator/main.py
+++ b/geojson_validator/main.py
@@ -73,7 +73,9 @@ def validate_geometries(
     geojson_input = input_to_geojson(geojson_input)
     fc = any_geojson_to_featurecollection(geojson_input)
 
-    geometries = [feature["geometry"] for feature in fc["features"]]
+    # A missing geometry member is treated like an explicit null geometry, which
+    # process_validation already reports as skipped.
+    geometries = [feature.get("geometry") for feature in fc["features"]]
     results = process_validation(geometries, criteria_invalid, criteria_problematic)
 
     logger.info(f"Validation results: {results}")

--- a/tests/test_geometry_validation.py
+++ b/tests/test_geometry_validation.py
@@ -35,6 +35,47 @@ def test_check_criteria_single_string_raises():
         )
 
 
+@pytest.mark.parametrize(
+    "geometry",
+    [
+        {"type": "Point", "coordinates": [1]},  # position with a single value
+        {"type": "Point", "coordinates": ["1", "2"]},  # non-numeric coordinate
+        {"type": "LineString", "coordinates": [[1, 2], [3, None]]},  # null coordinate
+        {"type": "Polygon", "coordinates": [[1, 2]]},  # not nested deep enough
+        {"type": "Polygon"},  # missing coordinates
+        {"type": "MultiPolygon"},  # missing coordinates, multi-geometry path
+        "a string, not an object",
+        True,
+    ],
+)
+def test_process_validation_skips_structurally_broken_geometry(geometry):
+    # These are reported properly by validate_structure; validate_geometries must skip
+    # them rather than raising IndexError/TypeError/KeyError/AttributeError.
+    results = geometry_validation.process_validation(
+        [geometry],
+        geometry_validation.INVALID_CRITERIA,
+        geometry_validation.PROBLEMATIC_CRITERIA,
+    )
+    assert results["skipped_validation"] == [0]
+    assert not results["invalid"]
+    assert not results["problematic"]
+
+
+def test_process_validation_skips_only_the_broken_geometry():
+    geometries = [
+        {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+        {"type": "Point", "coordinates": [1]},  # broken
+        {"type": "Polygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1]]]},
+    ]
+    results = geometry_validation.process_validation(
+        geometries,
+        geometry_validation.INVALID_CRITERIA,
+        geometry_validation.PROBLEMATIC_CRITERIA,
+    )
+    assert results["skipped_validation"] == [1]
+    assert results["invalid"]["unclosed"] == [2]  # the third geometry is still checked
+
+
 def test_process_validation_valid_polygon_without_criteria():
     geometries = [
         {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [1, 0], [0, 0]]]}

--- a/tests/test_geometry_validation.py
+++ b/tests/test_geometry_validation.py
@@ -76,6 +76,49 @@ def test_process_validation_skips_only_the_broken_geometry():
     assert results["invalid"]["unclosed"] == [2]  # the third geometry is still checked
 
 
+@pytest.mark.parametrize(
+    "geometry",
+    [
+        # Rings one level too shallow, so the sub-polygon itself is not checkable.
+        {"type": "MultiPolygon", "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 0]]]},
+        {"type": "MultiPoint", "coordinates": [[1]]},  # position with a single value
+        {"type": "GeometryCollection", "geometries": [False]},  # not an object
+        {"type": "GeometryCollection", "geometries": [None]},  # null sub-geometry
+    ],
+)
+def test_process_validation_skips_multi_geometry_with_broken_subgeometry(geometry):
+    # The skip of a sub-geometry must reach the result, otherwise a broken
+    # multi-geometry is indistinguishable from a valid one.
+    results = geometry_validation.process_validation(
+        [geometry],
+        geometry_validation.INVALID_CRITERIA,
+        geometry_validation.PROBLEMATIC_CRITERIA,
+    )
+    assert results["skipped_validation"] == [0]
+    assert not results["invalid"]
+    assert not results["problematic"]
+
+
+def test_process_validation_partly_broken_multi_geometry_is_skipped_and_flagged():
+    # A multi-geometry can be both: partly checked and flagged, partly not checkable.
+    geometries = [
+        {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [[0, 0], [1, 0], [1, 1], [0, 0]],  # broken, rings too shallow
+                [[[0, 0], [1, 0], [1, 1], [0, 1]]],  # checkable, and unclosed
+            ],
+        }
+    ]
+    results = geometry_validation.process_validation(
+        geometries,
+        geometry_validation.INVALID_CRITERIA,
+        geometry_validation.PROBLEMATIC_CRITERIA,
+    )
+    assert results["skipped_validation"] == [0]
+    assert results["invalid"]["unclosed"] == [{0: [1]}]
+
+
 def test_process_validation_valid_polygon_without_criteria():
     geometries = [
         {"type": "Polygon", "coordinates": [[[0, 0], [1, 1], [1, 0], [0, 0]]]}


### PR DESCRIPTION
`validate_geometries` indexed coordinate positions directly, so input that `validate_structure` reports perfectly cleanly instead crashed with a bare exception that says nothing about which feature is at fault:

```
Point [1]                    -> IndexError: list index out of range
Point ["1", "2"]             -> TypeError: type str doesn't define __round__
LineString [[1,2],[3,null]]  -> TypeError: '<=' not supported ...
Polygon without coordinates  -> KeyError: 'coordinates'
a geometry that is a string  -> AttributeError: 'str' object has no attribute 'get'
```

Those now report the feature index in `skipped_validation`, the same way null geometries and unparseable geometries already did. Deliberate input validation still raises. Over the 74 fixtures, 15 go from raising to returning a result; nothing that previously succeeded returns anything different.

Second commit fixes a related hole: the skip of a sub-geometry was dropped on the way out of the recursive call, so a MultiPolygon with one broken part came back with an empty `skipped_validation` and looked fully valid.

Stacked on #28.